### PR TITLE
Solved syntax errors and better translated strings into Spanish 

### DIFF
--- a/oxref.dtx
+++ b/oxref.dtx
@@ -15538,7 +15538,7 @@ reference,mvreference,inreference]{volume}{%
   conductors       = {{directores}{dirs\adddot}},
   serieseditor     = {{editor de la serie}{ed\adddotspace ser\adddot}},
   serieseditors    = {{editores de la serie}{eds\adddotspace ser\adddot}},
-  holder           = {{titular}{tit\adddot},
+  holder           = {{titular}{tit\adddot}},
   holders          = {{titulares}{tits\adddot}},
   editorcm         = {{editor y compilador}{ed\adddotspace y comp\adddot}},
   editorcms        = {{editores y compiladores}{eds\adddotspace y comps\adddot}},
@@ -15705,83 +15705,83 @@ reference,mvreference,inreference]{volume}{%
 % the abbreviated versions of the roles expressed as actions.
 %
 %    \begin{macrocode}
-  byeditor         = {{editado}{ed\adddotspace}},
+  byeditor         = {{editado por}{ed\adddotspace}},
   byredactor       = {{redacci\'on de}{red\adddotspace de}},
-  byreviser        = {{revisado}{rev\adddotspace}},
-  byreviewer       = {{rese\~nado}{res\adddotspace}},
-  byfounder        = {{fundado}{fund\adddotspace}},
-  bycontinuator    = {{continuado}{cont\adddotspace}},
+  byreviser        = {{revisado por}{rev\adddotspace}},
+  byreviewer       = {{rese\~nado por}{res\adddotspace}},
+  byfounder        = {{fundado por}{fund\adddotspace}},
+  bycontinuator    = {{continuado por}{cont\adddotspace}},
   bycollaborator   = {{colaboraci\'on de}{col\adddotspace de}},
-  bytranslator     = {{traducido \lbx@lfromlang\}{trad\adddotspace \lbx@sfromlang\}},
-  bycommentator    = {{comentado}{com\adddotspace}},
-  byannotator      = {{anotado}{anot\adddotspace}},
-  byeditortr       = {{editado y traducido \lbx@lfromlang\}%
-                      {ed\adddotspace y trad\adddotspace \lbx@sfromlang\}},
-  byeditorco       = {{editado y comentado}%
-                      {ed\adddotspace y com\adddotspace}},
-  byeditoran       = {{editado y anotado}%
-                      {ed\adddotspace y anot\adddotspace}},
-  byeditorin       = {{editado e introducido}%
+  bytranslator     = {{traducido \lbx@lfromlang\ por}{trad\adddotspace \lbx@sfromlang}},
+  bycommentator    = {{comentado por}{com\adddotspace}},
+  byannotator      = {{anotado por}{anot\adddotspace}},
+  byeditortr       = {{editado y traducido \lbx@lfromlang\ por}%
+                      {ed\adddotspace y trad\adddotspace \lbx@sfromlang}},
+  byeditorco       = {{editado y comentado por}%
+                      {ed\adddotspace y com\adddotspace }},
+  byeditoran       = {{edici\'on y notas de}%
+                      {ed\adddotspace y not\adddotspace}},
+  byeditorin       = {{edici\'on e introducci\'on de}%
                       {ed\adddotspace e intr\adddotspace}},
-  byeditorfo       = {{editado y prologado}%
+  byeditorfo       = {{edici\'on y pr\'ologo de}%
                       {ed\adddotspace y pr\'ol\adddotspace}},
-  byeditoraf       = {{editado y epilogado}%
+  byeditoraf       = {{edici\'on y ep\'ilogo de}%
                       {ed\adddotspace y ep\'il\adddotspace}},
-  byeditortrco     = {{editado, traducido \lbx@lfromlang\ y comentado}%
+  byeditortrco     = {{editado, traducido \lbx@lfromlang\ y comentado por}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ y com\adddotspace}},
-  byeditortran     = {{editado, traducido \lbx@lfromlang\ y anotado}%
-                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ y anot\adddotspace}},
-  byeditortrin     = {{editado, traducido \lbx@lfromlang\ e introducido}%
+  byeditortran     = {{edici\'on, traducci\'on \lbx@lfromlang\ y notas de}%
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ y not\adddotspace}},
+  byeditortrin     = {{edici\'on, traducci\'on \lbx@lfromlang\ e introducci\'on de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e intr\adddotspace}},
-  byeditortrfo     = {{editado, traducido \lbx@lfromlang\ y prologado}%
+  byeditortrfo     = {{edici\'on, traducci\'on \lbx@lfromlang\ y pr\'ologo de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ y pr\'ol\adddotspace}},
   byeditortraf     = {{editado, traducido \lbx@lfromlang\ y epilogado}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ y ep\'il\adddotspace}},
   byeditorcoin     = {{editado, comentado e introducido}%
                       {ed.,\addabbrvspace com\adddotspace e intr\adddotspace}},
-  byeditorcofo     = {{editado, comentado y prologado}%
+  byeditorcofo     = {{edici\'on, comentarios y pr\'ologo de}%
                       {ed.,\addabbrvspace com\adddotspace y pr\'ol\adddotspace}},
-  byeditorcoaf     = {{editado, comentado y epilogado}%
+  byeditorcoaf     = {{edici\'on, comentarios y ep\'ilogo de}%
                       {ed.,\addabbrvspace com\adddotspace y ep\'il\adddotspace}},
-  byeditoranin     = {{editado, anotado e introducido}%
+  byeditoranin     = {{edici\'on, notas e introducci\'on de}%
                       {ed.,\addabbrvspace anot\adddotspace e intr\adddotspace}},
-  byeditoranfo     = {{editado, anotado y prologado}%
+  byeditoranfo     = {{edici\'on, notas y pr\'ologo de}%
                       {ed.,\addabbrvspace anot\adddotspace y pr\'ol\adddotspace}},
-  byeditoranaf     = {{editado, anotado y epilogado}%
+  byeditoranaf     = {{edici\'on, notas y ep\'ilogo de}%
                       {ed.,\addabbrvspace anot\adddotspace y ep\'il\adddotspace}},
-  byeditortrcoin   = {{editado, traducido \lbx@lfromlang, comentado e introducido}%
+  byeditortrcoin   = {{edici\'on, traducci\'on \lbx@lfromlang, comentarios e introducci\'on de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, com\adddotspace e intr\adddotspace}},
-  byeditortrcofo   = {{editado, traducido \lbx@lfromlang, comentado y prologado}%
+  byeditortrcofo   = {{edici\'on, traducci\'on \lbx@lfromlang, comentarios y pr\'ologo de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, com\adddotspace y pr\'ol\adddotspace}},
-  byeditortrcoaf   = {{editado, traducido \lbx@lfromlang, comentado y epilogado}%
+  byeditortrcoaf   = {{edici\'on, traducci\'on \lbx@lfromlang, comentarios y ep\'ilogo de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, com\adddotspace y ep\'il\adddotspace}},
-  byeditortranin   = {{editado, traducido \lbx@lfromlang, anotado e introducido}%
+  byeditortranin   = {{edici\'on, traducci\'on \lbx@lfromlang, notas e introducci\'on de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, anot\adddotspace e intr\adddotspace}},
-  byeditortranfo   = {{editado, traducido \lbx@lfromlang, anotado y prologado}%
+  byeditortranfo   = {{edici\'on, traducci\'on \lbx@lfromlang, notas y pr\'ologo de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, anot\adddotspace y pr\'ol\adddotspace}},
-  byeditortranaf   = {{editado, traducido \lbx@lfromlang, anotado y epilogado}%
+  byeditortranaf   = {{edici\'on, traducci\'on \lbx@lfromlang, notas y ep\'ilogo de}%
                       {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang, anot\adddotspace y ep\'il\adddotspace}},
-  bytranslatorco   = {{traducido \lbx@lfromlang\ y comentado}%
+  bytranslatorco   = {{traducci\'on \lbx@lfromlang\ y comentarios de}%
                       {trad\adddotspace \lbx@sfromlang\ y com\adddotspace}},
-  bytranslatoran   = {{traducido \lbx@lfromlang\ y anotado}%
-                      {trad\adddotspace \lbx@sfromlang\ y anot\adddotspace}},
-  bytranslatorin   = {{traducido \lbx@lfromlang\ e introducido}%
+  bytranslatoran   = {{traducci\'on \lbx@lfromlang\ y notas de}%
+                      {trad\adddotspace \lbx@sfromlang\ y not\adddotspace}},
+  bytranslatorin   = {{traducci\'on \lbx@lfromlang\ e introducci\'on de}%
                       {trad\adddotspace \lbx@sfromlang\ e introd\adddotspace}},
-  bytranslatorfo   = {{traducido \lbx@lfromlang\ y prologado}%
+  bytranslatorfo   = {{traducci\'on \lbx@lfromlang\ y pr\'ologo de}%
                       {trad\adddotspace \lbx@sfromlang\ y pr\'ol\adddotspace}},
-  bytranslatoraf   = {{traducido \lbx@lfromlang\ y epilogado}%
+  bytranslatoraf   = {{traducci\'on \lbx@lfromlang\ y ep\'ilogo de}%
                       {trad\adddotspace \lbx@sfromlang\ y ep\'il\adddotspace}},
-  bytranslatorcoin = {{traducido \lbx@lfromlang, comentado e introducido}%
+  bytranslatorcoin = {{traducci\'on \lbx@lfromlang, comentarios e introducci\'on de}%
                       {trad\adddotspace \lbx@sfromlang, com\adddotspace e intr\adddotspace}},
-  bytranslatorcofo = {{traducido \lbx@lfromlang, comentado y prologado}%
+  bytranslatorcofo = {{traducci\'on \lbx@lfromlang, comentarios y pr\'ologo de}%
                       {trad\adddotspace \lbx@sfromlang, com\adddotspace y pr\'ol\adddotspace}},
-  bytranslatorcoaf = {{traducido \lbx@lfromlang, comentado y epilogado}%
+  bytranslatorcoaf = {{traducci\'on \lbx@lfromlang, comentarios y ep\'ilogo de}%
                       {trad\adddotspace \lbx@sfromlang, com\adddotspace y ep\'il\adddotspace}},
-  bytranslatoranin = {{traducido \lbx@lfromlang, anotado e introducido}%
+  bytranslatoranin = {{traducci\'on \lbx@lfromlang, notas e introducci\'on de}%
                       {trad\adddotspace \lbx@sfromlang, anot\adddotspace e intr\adddotspace}},
-  bytranslatoranfo = {{traducido \lbx@lfromlang, anotado y prologado}%
+  bytranslatoranfo = {{traducci\'on \lbx@lfromlang, notas y pr\'ologo}%
                       {trad\adddotspace \lbx@sfromlang, anot\adddotspace y pr\'ol\adddotspace}},
-  bytranslatoranaf = {{traducido \lbx@lfromlang, anotado y epilogado}%
+  bytranslatoranaf = {{traducci\'on \lbx@lfromlang, notas y ep\'ilogo}%
                       {trad\adddotspace \lbx@sfromlang, anot\adddotspace y ep\'il\adddotspace}},
 %    \end{macrocode}
 %
@@ -15811,50 +15811,50 @@ reference,mvreference,inreference]{volume}{%
 % \emph{New Hart's Rules} uses \enquote{accessed} for URL dates.
 %
 %    \begin{macrocode}
-  urlseen          = {{accessed}{accessed}},
+  urlseen          = {{accedido}{accedido}},
 %    \end{macrocode}
 %
 % Oxford style is to use \enquote{henceforth}
 % for shorthands and \enquote{at} to cite a page within a range.
 %
 %    \begin{macrocode}
-  citedas          = {{henceforth}{henceforth}},
-  thiscite         = {{at}{at}},
+  citedas          = {{en adelante}{en adelante}},
+  thiscite         = {{en}{en}},
 %    \end{macrocode}
 %
 % Languages are abbreviated.
 %
 %    \begin{macrocode}
-  langamerican     = {{ingl\'es americano}{ingl\'es americano}},
-  langbrazilian    = {{brasile\~no}{brasile\~no}},
-  langbulgarian    = {{b\'ulgaro}{b\'ulgaro}},
-  langcatalan      = {{catal\'an}{catal\'an}},
-  langcroatian     = {{croata}{croata}},
-  langczech        = {{checo}{checo}},
-  langdanish       = {{dan\'es}{dan\'es}},
-  langdutch        = {{neerland\'es}{neerland\'es}},
-  langenglish      = {{ingl\'es}{ingl\'es}},
-  langestonian     = {{estonio}{estonio}},
-  langfinnish      = {{fin\'es}{fin\'es}},
-  langfrench       = {{franc\'es}{franc\'es}},
-  langgalician     = {{gallego}{gallego}},
-  langgerman       = {{alem\'an}{alem\'an}},
-  langgreek        = {{griego}{griego}},
-  langhungarian    = {{h\'ungaro}{h\'ungaro}},
-  langitalian      = {{italiano}{italiano}},
-  langjapanese     = {{japon\'es}{japon\'es}},
-  langlatin        = {{lat\'in}{lat\'in}},
-  langlatvian      = {{lituano}{lituano}},
-  langnorwegian    = {{noruego}{noruego}},
-  langpolish       = {{polaco}{polaco}},
-  langportuguese   = {{portugu\'es}{portugu\'es}},
-  langrussian      = {{ruso}{ruso}},
-  langserbian      = {{serbio}{serbio}},
-  langslovak       = {{eslovaco}{eslovaco}},
-  langslovene      = {{esloveno}{esloveno}},
-  langspanish      = {{espa\~nol}{espa\~nol}},
+  langamerican     = {{ingl\'es americano}{ing\adddotspace amer\adddotspace}},
+  langbrazilian    = {{brasile\~no}{por\adddotspace bras\adddotspace}},
+  langbulgarian    = {{b\'ulgaro}{bul\adddotspace}},
+  langcatalan      = {{catal\'an}{cat\adddotspace}},
+  langcroatian     = {{croata}{hrv\adddotspace}},
+  langczech        = {{checo}{ces\adddotspace}},
+  langdanish       = {{dan\'es}{dan\adddotspace}},
+  langdutch        = {{neerland\'es}{nld\adddotspace}},
+  langenglish      = {{ingl\'es}{ing\adddotspace}},
+  langestonian     = {{estonio}{est\adddotspace}},
+  langfinnish      = {{fin\'es}{fin\adddotspace}},
+  langfrench       = {{franc\'es}{fra\adddotspace}},
+  langgalician     = {{gallego}{glg\adddotspace}},
+  langgerman       = {{alem\'an}{ale\adddotspace}},
+  langgreek        = {{griego}{gr\adddotspace}},
+  langhungarian    = {{h\'ungaro}{hun\adddotspace}},
+  langitalian      = {{italiano}{ita\adddotspace}},
+  langjapanese     = {{japon\'es}{jap\adddotspace}},
+  langlatin        = {{lat\'in}{lat\adddotspace}},
+  langlatvian      = {{lituano}{lit\adddotspace}},
+  langnorwegian    = {{noruego}{nor\adddotspace}},
+  langpolish       = {{polaco}{pol\adddotspace}},
+  langportuguese   = {{portugu\'es}{port\adddotspace}},
+  langrussian      = {{ruso}{rus\adddotspace}},
+  langserbian      = {{serbio}{srp\adddotspace}},
+  langslovak       = {{eslovaco}{slk\adddotspace}},
+  langslovene      = {{esloveno}{slv\adddotspace}},
+  langspanish      = {{espa\~nol}{esp\adddotspace}},
   langswedish      = {{sueco}{sueco}},
-  langukrainian    = {{ucraniano}{ucraniano}},
+  langukrainian    = {{ucraniano}{ucr\adddotspace}},
 }
 %    \end{macrocode}
 %


### PR DESCRIPTION
1. Syntax errors (critical, could not compile) 
- missed "}", line 15541
- bad endings in several appearances of "-fromlang" commands

2. Completion, improvements and normalization of translated strings into Spanish.